### PR TITLE
docs: updated leadership information for T2 2025 handover

### DIFF
--- a/src/content/docs/Teams and Contributions/2025 Trimester 2/company-handover.mdx
+++ b/src/content/docs/Teams and Contributions/2025 Trimester 2/company-handover.mdx
@@ -58,6 +58,7 @@ trimester, Thoth Tech will be running the two main products: OnTrack and SplashK
 - Mostafa Nouri - Senior Leader (OnTrack)
 - Joseph Kalayathankal Saji - Junior Leader (OnTrack)
 - Wael Alahmadi - Junior Leader (OnTrack)
+- Joshua Talev - Junior Leader (OnTrack)
 - Joshua Peyton Fernandes - Senior Leader (SplashKit)
 - Oliver Alexander Quail - Senior Leader (SplashKit)
 - Vishnu Vengadewaran - Senior Leader (SplashKit)

--- a/src/content/docs/Teams and Contributions/2025 Trimester 2/team-members-t2-2025.mdx
+++ b/src/content/docs/Teams and Contributions/2025 Trimester 2/team-members-t2-2025.mdx
@@ -24,7 +24,6 @@ title: Team Members T2 2025
 | Disuru Rathnayake       | Team Member            | Senior        |
 | Hasindu Welarathne      | Team Member            | Senior        |
 | Rachith Chandrathilake  | Team Member            | Junior        |
-| Brendan Huynh           | Team Leader            | Junior        |
 | Joshua Talev            | Team Leader            | Junior        |
 | Rashi Agrawal           | Team Member            | Junior        |
 | Wael Alahmadi           | Team Leader            | Junior        |


### PR DESCRIPTION
# Description

Updated the **Leadership Information** for Trimester 2, 2025 in the handover report.  
Changes include updating roles and responsibilities in:
- `company-handover.mdx` (Leadership Team section)
- `team-members-t2-2025.mdx` (Team Members table)

This ensures the report reflects the current leadership structure.

Fixes # (issue)

## Type of change

_Please delete options that are not relevant._

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [x] Documentation (update)

## How Has This Been Tested?

- Ran `npm run dev` and verified that the updated leadership information displays correctly on:
  - Teams and Contributions → 2025 Trimester 2 → Company Handover
  - Teams and Contributions → 2025 Trimester 2 → Team Members
- Confirmed formatting, roles, and names appear as expected.

## Testing Checklist

- [x] Have run `npm run format`
- [x] Have run `npm run build`
- [x] Have run `npm run dev` and/or `npm run preview`, using:
  - [x] Chrome
  - [ ] Safari
  - [ ] Firefox

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
